### PR TITLE
Document patching of Object.getOwnPropertyNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Wrapper.prototype = {
 
 ## Implementation
 
-Under the hood, `WeakMap` uses `Object.setProperty` to create a unique property on each object that is added to a `WeakMap`, then the value of that property is used as the key to perform lookups into a regular JavaScript `Object`.
+Under the hood, `WeakMap` uses `Object.setProperty` to create a unique property on each object that is added to a `WeakMap`, then the value of that property is used as the key to perform lookups into a regular JavaScript `Object`.  `Object.getOwnPropertyNames` is patched to avoid returning this unique property name.
 
 ## API Reference
 


### PR DESCRIPTION
I think this is a significant implementation detail and one that potential users would want to be aware of.  This PR adds a single sentence to the Implementation section of the README to cover it.

Thanks for considering,
Kevin